### PR TITLE
Include action to deploy kubeflow pipeline. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Below is a collection of GitHub Actions that we are curating or building that fa
   - [Action: Publish Container To a Generic Registry](https://github.com/marketplace/actions/publish-docker)
   
 ### 5. Compile and Push Pipeline to Kubeflow
-
+- [Action: To compile, deploy and run Kubeflow pipeline](https://github.com/marketplace/actions/kubeflow-compile-deploy-and-run). This action allows for improve MLOps together with [Kubeflow pipelines](https://www.kubeflow.org/docs/pipelines/overview/pipelines-overview/)
 
 ## What is MLOps?  
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Below is a collection of GitHub Actions that we are curating or building that fa
 ### 4. Publish Docker Images
   - [Action: Publish Container To The GitHub Package Registry](https://github.com/marketplace/actions/publish-docker-images-to-gpr).  See this [doc](https://github.com/features/package-registry) on more information on the GitHub Package Registry
   - [Action: Publish Container To a Generic Registry](https://github.com/marketplace/actions/publish-docker)
+  
+### 5. Compile and Push Pipeline to Kubeflow
+
 
 ## What is MLOps?  
 


### PR DESCRIPTION
I have previously had discussions with @hamelsmu  and the kubeflow community about building a github action to compile and deploy a Kubeflow pipeline to Kubeflow. I have done some initial work on creating such an action. In order to help contribute it to the community and get some feedback I would be happy to contribute the action to the repo, the code is currently [here](https://github.com/NikeNano/kubeflow-github-action) I am happy to restructure according to the structure you like to have it in this repo? Just let me know :) 

The goal with the actions is to do the following:
1) Compile a kubeflow pipeline
2) Upload the pipeline to Kubeflow

Possible add on: 
3) Run the pipeline
4) Schedule the pipeline to run

I am new to github actions so super happy for all feedback. 

I have had issues with the kfp.Client and could not go around this: 

https://github.com/NikeNano/kubeflow-github-action/blob/85c441f3b2a8585ba1d378f2189391b058fc09cc/entrypoint.sh#L3

please let me know if you have some ideas! 